### PR TITLE
Use cStringIO as default but keep StringIO as optional

### DIFF
--- a/ezodf/bytestreammanager.py
+++ b/ezodf/bytestreammanager.py
@@ -31,4 +31,5 @@ class ByteStreamManager(FileManager):
         return self._zipfile_as_bytes is not None
 
     def _open_bytestream(self):
+        self._zipfile_as_bytes.seek(0)
         return self._zipfile_as_bytes

--- a/ezodf/bytestreammanager.py
+++ b/ezodf/bytestreammanager.py
@@ -8,20 +8,20 @@ from __future__ import unicode_literals, print_function, division
 __author__ = "mozman <mozman@gmx.at>"
 
 
-from .compatibility import StringIO
+from .compatibility import is_stream, StringIO
 from .filemanager import FileManager
 
 
 class ByteStreamManager(FileManager):
     def __init__(self, buffer=None):
-        if isinstance(buffer, StringIO):
+        if is_stream(buffer):
             self._zipfile_as_bytes = buffer.getvalue()
         else:
             self._zipfile_as_bytes = buffer
         super(ByteStreamManager, self).__init__()
 
     def save(self, filename, backup=False):
-        if isinstance(filename, StringIO):
+        if is_stream(filename):
             filename.write(self.tobytes())
         else:
             with open(filename, 'wb') as fp:

--- a/ezodf/bytestreammanager.py
+++ b/ezodf/bytestreammanager.py
@@ -15,9 +15,9 @@ from .filemanager import FileManager
 class ByteStreamManager(FileManager):
     def __init__(self, buffer=None):
         if is_stream(buffer):
-            self._zipfile_as_bytes = buffer.getvalue()
-        else:
             self._zipfile_as_bytes = buffer
+        else:
+            self._zipfile_as_bytes = StringIO(buffer)
         super(ByteStreamManager, self).__init__()
 
     def save(self, filename, backup=False):
@@ -31,4 +31,4 @@ class ByteStreamManager(FileManager):
         return self._zipfile_as_bytes is not None
 
     def _open_bytestream(self):
-        return StringIO(self._zipfile_as_bytes)
+        return self._zipfile_as_bytes

--- a/ezodf/bytestreammanager.py
+++ b/ezodf/bytestreammanager.py
@@ -15,9 +15,9 @@ from .filemanager import FileManager
 class ByteStreamManager(FileManager):
     def __init__(self, buffer=None):
         if is_stream(buffer):
-            self._zipfile_as_bytes = buffer
+            self._zipfile_as_bytes = buffer.getvalue()
         else:
-            self._zipfile_as_bytes = StringIO(buffer)
+            self._zipfile_as_bytes = buffer
         super(ByteStreamManager, self).__init__()
 
     def save(self, filename, backup=False):
@@ -31,5 +31,4 @@ class ByteStreamManager(FileManager):
         return self._zipfile_as_bytes is not None
 
     def _open_bytestream(self):
-        self._zipfile_as_bytes.seek(0)
-        return self._zipfile_as_bytes
+        return StringIO(self._zipfile_as_bytes)

--- a/ezodf/compatibility.py
+++ b/ezodf/compatibility.py
@@ -40,8 +40,9 @@ if PY3:
 
 else: # PY2
     # distiguish StringIO
-    from StringIO import StringIO
+    from cStringIO import StringIO
     from cStringIO import InputType, OutputType
+    from StringIO import SlowStringIO
 
     tostr=unicode
     def is_string(value):
@@ -80,4 +81,4 @@ else: # PY2
     def is_stream(instance):
         return (isinstance(instance, InputType) or
                 isinstance(instance, OutputType) or
-                isinstance(instance, StringIO))
+                isinstance(instance, SlowStringIO))

--- a/ezodf/compatibility.py
+++ b/ezodf/compatibility.py
@@ -42,7 +42,7 @@ else: # PY2
     # distiguish StringIO
     from cStringIO import StringIO
     from cStringIO import InputType, OutputType
-    from StringIO import SlowStringIO
+    from StringIO import StringIO as SlowStringIO
 
     tostr=unicode
     def is_string(value):

--- a/ezodf/compatibility.py
+++ b/ezodf/compatibility.py
@@ -35,9 +35,13 @@ if PY3:
     def bytes2unicode(bytes):
         return str(bytes, 'utf-8')
 
+    def is_stream(instance):
+        return  isinstance(instance, StringIO)
+
 else: # PY2
     # distiguish StringIO
     from StringIO import StringIO
+    from cStringIO import InputType, OutputType
 
     tostr=unicode
     def is_string(value):
@@ -72,3 +76,8 @@ else: # PY2
                 f.write(data.getvalue())
                 f.flush()
                 return zipfile.is_zipfile(tmp)
+
+    def is_stream(instance):
+        return (isinstance(instance, InputType) or
+                isinstance(instance, OutputType) or
+                isinstance(instance, StringIO))

--- a/ezodf/document.py
+++ b/ezodf/document.py
@@ -7,7 +7,6 @@
 from __future__ import unicode_literals, print_function, division
 __author__ = "mozman <mozman@gmx.at>"
 
-import zipfile
 import os
 from .compatibility import tostr, is_bytes, is_zipfile, StringIO, is_stream
 from .const import MIMETYPES, MIMETYPE_BODYTAG_MAP, FILE_EXT_FOR_MIMETYPE

--- a/ezodf/document.py
+++ b/ezodf/document.py
@@ -81,7 +81,7 @@ def newdoc(doctype="odt", filename="", template=None):
 def _new_doc_from_template(filename, templatename):
     # TODO: only works with zip packaged documents
     def get_filemanager(buffer):
-        if isinstance(buffer, StringIO):
+        if is_stream(buffer):
             return ByteStreamManager(buffer)
         elif is_valid_stream(buffer):
             return ByteStreamManager(buffer)

--- a/ezodf/document.py
+++ b/ezodf/document.py
@@ -9,8 +9,7 @@ __author__ = "mozman <mozman@gmx.at>"
 
 import zipfile
 import os
-
-from .compatibility import tostr, is_bytes, is_zipfile, StringIO
+from .compatibility import tostr, is_bytes, is_zipfile, StringIO, is_stream
 from .const import MIMETYPES, MIMETYPE_BODYTAG_MAP, FILE_EXT_FOR_MIMETYPE
 from .xmlns import subelement, CN, etree, wrap, ALL_NSMAP, fake_element
 from .filemanager import FileManager
@@ -39,7 +38,7 @@ def is_valid_stream(buffer):
 
 
 def opendoc(filename):
-    if isinstance(filename, StringIO):
+    if is_stream(filename):
         fm = ByteStreamManager(filename)
     elif filename is not None:
         fm = FileManager(filename)

--- a/ezodf/filemanager.py
+++ b/ezodf/filemanager.py
@@ -14,7 +14,8 @@ from datetime import datetime
 
 from .xmlns import etree, CN
 from .manifest import Manifest
-from .compatibility import tobytes, bytes2unicode, is_bytes, is_zipfile, StringIO
+from .compatibility import tobytes, bytes2unicode, is_bytes, is_zipfile
+from .compatibility import is_stream, StringIO
 
 FNCHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 
@@ -77,7 +78,7 @@ class FileManager(object):
     def save(self, filename, backup=True):
         # always create a new zipfile
         write_to_memory = False
-        if isinstance(filename, StringIO):
+        if is_stream(filename):
             write_to_memory = True
         if write_to_memory:
             tmpfilename = filename

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -20,7 +20,6 @@ except ImportError:
 # trusted or separately tested modules
 from mytesttools import getdatafile
 from ezodf.filemanager import check_zipfile_for_oasis_validity
-from ezodf.xmlns import fake_element
 
 # objects to test
 from ezodf import document, const
@@ -181,12 +180,12 @@ class TestNewFromInMemoryTemplate(unittest.TestCase):
 
 
 if not PY3:
-    from cStringIO import StringIO as c_StringIO
+    from StringIO import StringIO as SlowStringIO
     class TestOdsIncStringIO(TestOdsInMemory):
-        stream_class_or_callable = c_StringIO
+        stream_class_or_callable = SlowStringIO
 
     class TestNewFromIncStringTemplate(TestNewFromInMemoryTemplate):
-        stream_class_or_callable = c_StringIO
+        stream_class_or_callable = SlowStringIO
 
 
 if __name__=='__main__':


### PR DESCRIPTION
It was claimed that [cStringIO is faster than StringIO](https://docs.python.org/2/library/stringio.html#module-cStringIO). Hence it would be beneficial to use cStringIO as default and keep StringIO as optional for the freedom of developer.

3 extra test cases was created under Python 2.x in order to test both StringIO and cStringIO in this PR. 
