### PR TITLE
MANIFEST.in: LICENSE.rst -> LICENSE.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include NEWS.txt README.rst LICENSE.rst TODO.rst
+include NEWS.txt README.rst LICENSE.txt TODO.rst
 include runtests.bat
 include runtests.py
 include version.py


### PR DESCRIPTION
The license is a `.txt`, not a `.rst`. This just switches the types.