### PR TITLE
22 - Reenable support for Flat XML OpenDocumentFormat files

### DIFF
--- a/ezodf/const.py
+++ b/ezodf/const.py
@@ -14,12 +14,14 @@ GENERATOR = "http://pypi.python.org/pypi/ezodf/%s$Python%s" % (VERSION, sys.vers
 
 MIMETYPES = {
     'odt': "application/vnd.oasis.opendocument.text",
+    'fodt': "application/xml",
     'ott': "application/vnd.oasis.opendocument.text-template",
     'odg': "application/vnd.oasis.opendocument.graphics",
     'otg': "application/vnd.oasis.opendocument.graphics-template",
     'odp': "application/vnd.oasis.opendocument.presentation",
     'otp': "application/vnd.oasis.opendocument.presentation-template",
     'ods': "application/vnd.oasis.opendocument.spreadsheet",
+    'fods': "application/xml",
     'ots': "application/vnd.oasis.opendocument.spreadsheet-template",
     'odc': "application/vnd.oasis.opendocument.chart",
     'otc': "application/vnd.oasis.opendocument.chart-template",

--- a/ezodf/document.py
+++ b/ezodf/document.py
@@ -39,17 +39,17 @@ def is_valid_stream(buffer):
 def opendoc(filename):
     if is_stream(filename):
         fm = ByteStreamManager(filename)
-    elif filename is not None:
-        fm = FileManager(filename)
     else:
+        fm = FileManager(filename)
+
+    mime_type = __detect_mime_type(fm)
+    if (mime_type == "application/xml"):
         try:
             xmlnode = etree.parse(filename).getroot()
             return FlatXMLDocument(filename=filename, xmlnode=xmlnode)
         except etree.ParseError:
-            raise IOError("File '%s' is neither a zip-package nor a flat "
-                          "XML OpenDocumentFormat file." % filename)
-
-    mime_type = __detect_mime_type(fm)
+            raise IOError("File '%s' is detected as a flat "
+                          "XML OpenDocumentFormat file but failed to be parsed." % filename)
     return PackagedDocument(filemanager=fm, mimetype=mime_type)
 
 
@@ -64,7 +64,7 @@ def __detect_mime_type(file_manager):
     else:
         # use file ext name
         ext = os.path.splitext(file_manager.zipname)[1]
-        mime_type = MIMETYPES[ext]
+        mime_type = MIMETYPES[ext[1:]]
     return mime_type
 
 


### PR DESCRIPTION
A ".fodt" document is already in the repository.
I could test my commit with this small modification :
```diff
diff --git a/tests/test_variables.py b/tests/test_variables.py
index a02b2fc..bc46de9 100644
--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -107,7 +107,7 @@ class TestSimpleVariables(unittest.TestCase):  # {{{1
 
     def test_simple_variables_integeational(self):  # {{{2
         """Not exactly unittest but very usefull"""
-        doc = opendoc("tests/data/variables.odt")
+        doc = opendoc("tests/data/variables.fodt")
         self.assertTrue(isinstance(doc.body.variables,
                                    GenericWrapper))
         self.assertTrue(isinstance(doc.body.variables,

```

But I didn't dig into the test code, I let the addition of the test to read a ".fodt" document to someone else.